### PR TITLE
Alteração na regex

### DIFF
--- a/src/services/regex.ts
+++ b/src/services/regex.ts
@@ -2,7 +2,7 @@ import { Item } from "@/types";
 
 export default function processInputWithRegex(text: string) {
   
-  const regex = /^(\d+(?:\.\d+)?)\s*(?=\d|\.)?(kg|g)?\s+(de\s+)?(.+)/i;
+  const regex = /^([1-9]\d*(?:\.\d+)?)\s*(k?g)?\s+(?:de\s+)?(.+)/i;
   const match = regex.exec(text);
 
   if (!match) {
@@ -16,7 +16,7 @@ export default function processInputWithRegex(text: string) {
 
   const quantity = parseFloat(match[1]);
   const unit = match[2]?.toLowerCase() || 'un';
-  const name = match[4].trim();
+  const name = match[3].trim();
 
   return {
     quantity,


### PR DESCRIPTION
Troquei o início por `[1-9]\d*` - assim o primeiro dígito não pode ser zero (antes aceitava "_0g de presunto_", agora o primeiro dígito tem que ser entre 1 e 9 - os demais podem ser qualquer valor). Só que agora não vai aceitar, por exemplo, "_0.5kg_", então veja o que faz mais sentido no seu caso).

O lookaround `(?=\d|\.)?` não servia para nada (ele verifica se na frente tinha um número ou um ponto, e tudo isso era opcional, mas isso de certa forma já foi verificado antes), então pode ser removido.

Em vez de `kg|g`, pode usar `k?g` (`k?` indica que o "k" é opcional, ou seja, pode ser "kg" ou "g").

O `(de\s+)` não é capturado depois, então pode trocar para um grupo de não-captura: `(?:de\s+)` - assim, o `name` estará no grupo 3 em vez do 4 (melhor, pois não cria grupos à toa).