### PR TITLE
Refact env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+APP_URL=http://localhost:3000
+
+# MONGO DB
+MONGO_URI=your_mongo_uri
+MONGO_DB=your_db_name

--- a/src/models/database.ts
+++ b/src/models/database.ts
@@ -1,6 +1,7 @@
 import { Db, MongoClient } from "mongodb"
 
-const uri = process.env.MONGODB_URI as string
+const uri = process.env.MONGO_URI as string
+const databaseName = process.env.MONGO_DB as string
 
 let cachedDb: null | Db;
 
@@ -11,7 +12,8 @@ export default async function connectToDatabase() {
   }
 
   const client = new MongoClient(uri)  
-  const db = client.db("marketlist")
+  const db = client.db(databaseName)
   cachedDb = db
+  
   return db
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 
+const appUrl = process.env.APP_URL as string
+
 const api = axios.create({
-  // baseURL: "http://localhost:3000/api/",
-  baseURL: "https://supermarket-list-rouge.vercel.app/api/",
+  baseURL: appUrl + "/api",
 })
 
 export default api


### PR DESCRIPTION
I make some changes to get ease for init app.

- Add .env.example
    - Run `cp .env.example .env` for generate new .env with the variables examples
- Add application url in .env
    - In `src/services/api.ts`, there was baseUrl defined manually, whenever you want change production/dev, your have change the code. Thats why i created APP_URL env
- Add database name in .env
    - In `src/models/database.ts`, the database name was defined manually, same problem of the topic above